### PR TITLE
Updated runtests.py to support Django 1.8

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import sys
 import os
+import django
 from os.path import dirname, abspath
 from optparse import OptionParser
 
@@ -21,10 +22,13 @@ if not settings.configured and not os.environ.get('DJANGO_SETTINGS_MODULE'):
         DEBUG=False,
     )
 
-from django.test.simple import DjangoTestSuiteRunner
+from django.test.runner import DiscoverRunner
 
 
 def runtests(*test_args, **kwargs):
+
+    django.setup()
+
     if 'south' in settings.INSTALLED_APPS:
         from south.management.commands import patch_for_test_db_setup
         patch_for_test_db_setup()
@@ -33,7 +37,7 @@ def runtests(*test_args, **kwargs):
         test_args = ['tests']
     parent = dirname(abspath(__file__))
     sys.path.insert(0, parent)
-    test_runner = DjangoTestSuiteRunner(verbosity=kwargs.get('verbosity', 1), interactive=kwargs.get('interactive', False), failfast=kwargs.get('failfast'))
+    test_runner = DiscoverRunner(verbosity=kwargs.get('verbosity', 1), interactive=kwargs.get('interactive', False), failfast=kwargs.get('failfast'))
     failures = test_runner.run_tests(test_args)
     sys.exit(failures)
 


### PR DESCRIPTION
Django 1.6 deprecated DjangoTestSuiteRunner and Django 1.8 dropped it.
Since Django 1.7, if you're running Django in a plain Python script and rely on the DJANGO_SETTINGS_MODULE environment variable, you need to explicitly initialize Django at the beginning using django.setup().

See https://docs.djangoproject.com/en/1.8/releases/1.6/#new-test-runner and https://docs.djangoproject.com/en/1.8/releases/1.7/#standalone-scripts